### PR TITLE
Add GitLab Pipelines by puzl.cloud

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Continuous Integration provides continuous feedback on code integrations, helpin
 * **[Bamboo](https://www.atlassian.com/software/bamboo)** (Free & Enterprise): A continuous integration and deployment tool that ties automated builds, tests, and releases together in a single workflow.
 * **[RazorOps CICD](https://razorops.com/)** (Free & Paid): YAML-based CI/CD that is container-first SaaS cloud version and On-Prems with large Enterprise.
 * **[Buildkite](https://buildkite.com/)** (Free & Paid): YAML-based CI/CD.
+* **[GitLab Pipelines by puzl.cloud](https://gitlab-pipelines.puzl.cloud)** (Paid): Blazing-fast execution layer for GitLab CI/CD pipeline jobs, offering per-second billing and k8s API for runner management.
 
 ## Artifact Management Tools
 


### PR DESCRIPTION
[Puzl](https://puzl.cloud) is a modern cloud platform focusing on cost-effective runtime. You can run cloud workloads and pay for their pure CPU and memory consumption, not for the idle of cloud instances. In this request, I submit our new SaaS service for running GitLab CI/CD pipelines.