### PR TITLE
Changing DeployBot for DeployHQ

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Continuous Integration provides continuous feedback on code integrations, helpin
 * **[Bamboo](https://www.atlassian.com/software/bamboo)** (Free & Enterprise): A continuous integration and deployment tool that ties automated builds, tests, and releases together in a single workflow.
 * **[RazorOps CICD](https://razorops.com/)** (Free & Paid): YAML-based CI/CD that is container-first SaaS cloud version and On-Prems with large Enterprise.
 * **[Buildkite](https://buildkite.com/)** (Free & Paid): YAML-based CI/CD.
-* **[DeployBot](https://www.deploybot.com/)** (Free & Paid): A cloud-based CI/CD service that supports building, deploying and automating any project.
+* **[DeployHQ](https://www.deployhq.com/)** (Free & Paid): A cloud-based CI/CD service that supports building, deploying and automating any project.
 
 ## Artifact Management Tools
 


### PR DESCRIPTION
DeployHQ is now part of DeployBot, currently in a merger: https://deploybot.com/blog/deploybot-and-deployhq-merge-announcement